### PR TITLE
Make imports available directly from the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ The `v2` environment is over 100 times faster than the `v1` environment. However
 
 ```python
 
-from gym_chess.envs import ChessEnvV1, ChessEnvV2
+from gym_chess import ChessEnvV1, ChessEnvV2
 
 env_v1 = ChessEnvV1()
 env_v2 = ChessEnvV2()

--- a/gym_chess/test/v1/test_basic_moves.py
+++ b/gym_chess/test/v1/test_basic_moves.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV1
+from gym_chess import ChessEnvV1
 from gym_chess.envs.chess_v1 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v1/test_benchmark.py
+++ b/gym_chess/test/v1/test_benchmark.py
@@ -2,7 +2,7 @@ import time
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV1
+from gym_chess import ChessEnvV1
 from gym_chess.test.utils import run_test_funcs
 
 

--- a/gym_chess/test/v1/test_capture_moves.py
+++ b/gym_chess/test/v1/test_capture_moves.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV1
+from gym_chess import ChessEnvV1
 from gym_chess.envs.chess_v1 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v1/test_castle_moves.py
+++ b/gym_chess/test/v1/test_castle_moves.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV1
+from gym_chess import ChessEnvV1
 from gym_chess.envs.chess_v1 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v1/test_king_moves.py
+++ b/gym_chess/test/v1/test_king_moves.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV1
+from gym_chess import ChessEnvV1
 from gym_chess.envs.chess_v1 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v1/test_run_moves.py
+++ b/gym_chess/test/v1/test_run_moves.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV1
+from gym_chess import ChessEnvV1
 from gym_chess.envs.chess_v1 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v1/test_squares_under_attack.py
+++ b/gym_chess/test/v1/test_squares_under_attack.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV1
+from gym_chess import ChessEnvV1
 from gym_chess.envs.chess_v1 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v2/test_basic_moves.py
+++ b/gym_chess/test/v2/test_basic_moves.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV2
+from gym_chess import ChessEnvV2
 from gym_chess.envs.chess_v2 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v2/test_benchmark.py
+++ b/gym_chess/test/v2/test_benchmark.py
@@ -2,7 +2,7 @@ import time
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV2
+from gym_chess import ChessEnvV2
 from gym_chess.test.utils import run_test_funcs
 
 

--- a/gym_chess/test/v2/test_capture_moves.py
+++ b/gym_chess/test/v2/test_capture_moves.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV2
+from gym_chess import ChessEnvV2
 from gym_chess.envs.chess_v1 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v2/test_castle_moves.py
+++ b/gym_chess/test/v2/test_castle_moves.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV2
+from gym_chess import ChessEnvV2
 from gym_chess.envs.chess_v2 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v2/test_king_moves.py
+++ b/gym_chess/test/v2/test_king_moves.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV2
+from gym_chess import ChessEnvV2
 from gym_chess.envs.chess_v2 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v2/test_run_moves.py
+++ b/gym_chess/test/v2/test_run_moves.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV2
+from gym_chess import ChessEnvV2
 from gym_chess.envs.chess_v1 import (
     KING_ID,
     QUEEN_ID,

--- a/gym_chess/test/v2/test_squares_under_attack.py
+++ b/gym_chess/test/v2/test_squares_under_attack.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import numpy as np
-from gym_chess.envs import ChessEnvV2
+from gym_chess import ChessEnvV2
 from gym_chess.envs.chess_v1 import (
     KING_ID,
     QUEEN_ID,


### PR DESCRIPTION
You can import the environments directly from root module

```python

from gym_chess import ChessEnvV1, ChessEnvV2

```

